### PR TITLE
Optimize unused public vars

### DIFF
--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -12,7 +12,6 @@
                              :exclude [com.cognitect/transit-clj]}
         com.cognitect/transit-clj {:mvn/version "1.0.329"}
         com.github.clj-easy/stub {:mvn/version "0.2.3"}
-        com.climate/claypoole {:mvn/version "1.1.4"}
         lsp4clj/protocols {:local/root "../protocols"}}
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {clojure-lsp/common-test {:local/root "../common-test"}

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -205,3 +205,250 @@
          (remove #(identical? :clojure-lsp/unused-public-var (:type %)))
          (concat kondo-findings)
          vec)))
+
+(comment
+  (require '[criterium.core :as bm])
+  (require '[clj-async-profiler.core :as profiler])
+  (require '[clojure.string :as string])
+
+  (defn lint-file [filename]
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          definitions (file-definitions project-analysis filename)
+          parallelize-fn (if false pmap pmap-light)]
+      (->> definitions
+           (remove (partial exclude-public-diagnostic-definition? nil))
+           (parallelize-fn #(when (= 0 (count (q/find-references project-analysis % false db)))
+                              %))
+           (remove nil?)
+           (group-by :filename))))
+
+  (defn lint-project []
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          definitions (project-definitions project-analysis)
+          parallelize-fn (if true pmap pmap-light)]
+      (->> definitions
+           (remove (partial exclude-public-diagnostic-definition? nil))
+           (parallelize-fn #(when (= 0 (count (q/find-references project-analysis % false db)))
+                              %))
+           (remove nil?)
+           (group-by :filename))))
+
+  (defn find-references-v2
+    [analysis element include-declaration? _db]
+    (let [names (q/var-definition-names element)
+          exclude-declaration? (not include-declaration?)]
+      (sequence
+        (comp
+          (mapcat val)
+          (remove (fn rm-kww [reference] (identical? :keywords (:bucket reference))))
+          (filter (fn matches-name [reference] (contains? names (:name reference))))
+          (filter (fn matches-ns [reference] (#'q/safe-equal? (:ns element) (or (:ns reference) (:to reference)))))
+          (remove (fn exclude-decl [reference]
+                    (and exclude-declaration?
+                         (or
+                           (identical? :var-definitions (:bucket reference))
+                            ;; usage from own definition
+                           (and (:from-var reference)
+                                (= (:from-var reference) (:name element))
+                                (= (:from reference) (:ns element)))
+                           (:defmethod reference)))))
+          (medley/distinct-by
+            (fn distinction [{:keys [filename name row col]}]
+              [filename name row col])))
+        analysis)))
+
+  (defn lint-file-v2
+    ;; 102 -> 178ms
+    [filename]
+    (let [db db/db
+          analysis (:analysis @db)
+          project-analysis (q/filter-project-analysis analysis db)
+          definitions (file-definitions project-analysis filename)]
+      (->> definitions
+           (remove (partial exclude-public-diagnostic-definition? nil))
+           (keep #(when (not (seq (find-references-v2 project-analysis % false db)))
+                    %))
+           (group-by :filename))))
+
+  (defn lint-usages-v3
+    ;; 102 -> 10.1 ms
+    [var-definitions kw-definitions project-analysis db]
+    (let [var-nses (set (map :ns var-definitions))
+          kw-signature (juxt :ns :name)
+          kws (set (map kw-signature kw-definitions))
+          usages (medley/map-vals (fn [elems]
+                                    (filter #(case (:bucket %)
+                                               :var-usages (contains? var-nses (:to %))
+                                               :keywords (contains? kws (kw-signature %))
+                                               false)
+                                            elems))
+                                  project-analysis)]
+      (->> (concat var-definitions
+                   kw-definitions)
+           (remove (partial exclude-public-diagnostic-definition? nil))
+           (keep #(when (not (seq (q/find-references usages % false db)))
+                    %))
+           (group-by :filename))))
+
+  (defn lint-file-v3
+    ;; 102 -> 10.1 ms
+    [filename]
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          var-definitions (q/find-var-definitions project-analysis filename false)
+          kw-definitions (q/find-keyword-definitions project-analysis filename)]
+      (lint-usages-v3 var-definitions kw-definitions project-analysis db)))
+
+  (defn lint-project-v3
+    ;; 1140 -> 612ms
+    []
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          var-definitions (q/find-all-var-definitions project-analysis)
+          kw-definitions (q/find-all-keyword-definitions project-analysis)]
+      (lint-usages-v3 var-definitions kw-definitions project-analysis db)))
+
+  (defn lint-project-v4
+    []
+    (let [db db/db
+          analysis (:analysis @db)
+          project-analysis (q/filter-project-analysis analysis db)
+          var-definitions (->> project-analysis
+                               q/find-all-var-definitions
+                               (remove (partial exclude-public-diagnostic-definition? nil)))
+          signature (juxt :ns :name)
+          var-defs-by-sign (group-by signature var-definitions)
+          kw-definitions (->> project-analysis
+                              q/find-all-keyword-definitions
+                              (remove (partial exclude-public-diagnostic-definition? nil)))
+          kw-defs-by-sign (group-by signature kw-definitions)
+
+          var-usage-signs (into #{}
+                                (comp
+                                  (mapcat val)
+                                  (filter (fn rm-kw [reference] (identical? :var-usages (:bucket reference))))
+                                  (remove (fn rm-decl [reference]
+                                            (or
+                                             ;; usage from own definition
+                                              (and (:from-var reference)
+                                                   (= (:from-var reference) (:name reference))
+                                                   (= (:from reference) (:to reference)))
+                                              (:defmethod reference))))
+                                  (map (juxt :to :name)))
+                                project-analysis)
+          kw-usage-signs (into #{}
+                               (comp
+                                 (mapcat val)
+                                 (filter (fn rm-kw [reference] (identical? :keywords (:bucket reference))))
+                                 (remove (fn rm-decl [reference]
+                                           (:reg reference)))
+                                 (map signature))
+                               project-analysis)]
+      (merge-with concat
+                  (->> (apply dissoc kw-defs-by-sign kw-usage-signs)
+                       (mapcat val)
+                       (group-by :filename))
+                  (->> (apply dissoc var-defs-by-sign var-usage-signs)
+                       (mapcat val)
+                       (keep #(when (not (seq (q/find-references project-analysis % false db)))
+                                %))
+                       (group-by :filename)))))
+
+  (defn lint-usages-v5
+    [var-defs kw-defs project-analysis]
+    (let [var-definitions (remove (partial exclude-public-diagnostic-definition? nil) var-defs)
+          var-nses (set (map :ns var-definitions)) ;; optimization to limit usages to internal namespaces, or in the case of a single file, to its namespaces
+          var-usages (into #{}
+                           (comp
+                             (mapcat val)
+                             (filter #(identical? :var-usages (:bucket %)))
+                             (filter #(contains? var-nses (:to %)))
+                             (remove q/var-usage-from-own-definition?)
+                             (map (juxt :to :name)))
+                           project-analysis)
+          var-used? (fn [var-def]
+                      (some (fn [var-name]
+                              (contains? var-usages [(:ns var-def) var-name]))
+                            (q/var-definition-names var-def)))
+          kw-signature (juxt :ns :name)
+          kw-definitions (remove (partial exclude-public-diagnostic-definition? nil) kw-defs)
+          kw-usages (into #{}
+                          (comp
+                            (mapcat val)
+                            (filter #(identical? :keywords (:bucket %)))
+                            (remove :reg)
+                            (map kw-signature))
+                          project-analysis)
+          kw-used? (fn [kw-def]
+                     (contains? kw-usages (kw-signature kw-def)))]
+      (->> (concat (remove var-used? var-definitions)
+                   (remove kw-used? kw-definitions))
+           (group-by :filename))))
+
+  (defn lint-project-v5
+    []
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          var-definitions (q/find-all-var-definitions project-analysis)
+          kw-definitions (q/find-all-keyword-definitions project-analysis)]
+      (lint-usages-v5 var-definitions kw-definitions project-analysis)))
+
+  (defn lint-file-v5
+    [filename]
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          var-definitions (q/find-var-definitions project-analysis filename false)
+          kw-definitions (q/find-keyword-definitions project-analysis filename)]
+      (lint-usages-v5 var-definitions kw-definitions project-analysis)))
+
+  (def initial-result (set (lint-project)))
+  initial-result
+
+  ;; kw heavy file
+  (def test-file "/Users/jmaine/workspace/opensource/clojure-lsp/lsp4clj/src/lsp4clj/coercer.clj")
+  ;; large file
+  (def test-file "/Users/jmaine/workspace/opensource/clojure-lsp/lib/src/clojure_lsp/queries.clj")
+
+  (time (medley/map-vals count (lint-file test-file)))
+  (time (medley/map-vals count (lint-file-v2 test-file)))
+  (time (medley/map-vals count (lint-file-v3 test-file)))
+  (time (medley/map-vals count (lint-file-v5 test-file)))
+
+  (time (= (lint-file test-file)
+           (lint-file-v5 test-file)))
+
+  (time (medley/map-vals count (lint-project)))
+  (time (medley/map-vals count (lint-project-v3)))
+  (time (medley/map-vals count (lint-project-v4)))
+  (time (medley/map-vals count (lint-project-v5)))
+
+  (time (= (lint-project) (lint-project-v4)))
+  (time (= (lint-project) (lint-project-v5)))
+
+  (profiler/profile {:min-width 5
+                     :return-file true
+                     :transform (fn [s]
+                                  (string/replace s #"clojure.lsp" "lsp"))}
+                    (time (dotimes [_ 300] (lint-file test-file))))
+
+  (bm/quick-bench (lint-file test-file))
+  (bm/quick-bench (lint-file-v2 test-file))
+  (bm/quick-bench (lint-file-v3 test-file))
+  (bm/quick-bench (lint-file-v5 test-file))
+
+  (profiler/profile {:min-width 5
+                     :return-file true
+                     :transform (fn [s]
+                                  (string/replace s #"clojure.lsp" "lsp"))}
+                    (time (dotimes [_ 10] (lint-project))))
+  (profiler/profile {:min-width 5
+                     :return-file true
+                     :transform (fn [s]
+                                  (string/replace s #"clojure.lsp" "lsp"))}
+                    (time (dotimes [_ 400] (lint-project-v5))))
+
+  (bm/quick-bench (lint-project))
+  (bm/quick-bench (lint-project-v3))
+  (bm/quick-bench (lint-project-v5)))

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -60,7 +60,7 @@
     , #{name (symbol (str "->" name))}
     , #{name}))
 
-(defn var-usage-from-own-definition? [usage]
+(defn ^:private var-usage-from-own-definition? [usage]
   (and (:from-var usage)
        (= (:from-var usage) (:name usage))
        (= (:from usage) (:to usage))))
@@ -613,3 +613,16 @@
         (-> excluded-full-qualified-vars
             set
             (contains? fqsn)))))
+
+(defn xf-all-var-usages-to-namespaces [namespaces]
+  (comp
+    (mapcat val)
+    (filter #(identical? :var-usages (:bucket %)))
+    (filter #(contains? namespaces (:to %)))
+    (remove var-usage-from-own-definition?)))
+
+(def xf-all-keyword-usages
+  (comp
+    (mapcat val)
+    (filter #(identical? :keywords (:bucket %)))
+    (remove :reg)))


### PR DESCRIPTION
The baseline algorithm for finding unused public vars has the following performance characteristics.

|               |   time | std-dev |
|---------------|-------:|--------:|
| large file    |   `98` ms |     `1` ms |
| kw-heavy file |  `249` ms |    `11` ms |
| whole project | `1220` ms |    `11` ms |

This was run on clojure-lsp itself, using queries.clj as a large file and coercer.clj as a file with many keyword definitions.

This commit researches several faster algorithms. Let's focus on the last algorithm, "v5". Its performance is significantly better:

|               | time | std-dev |
|---------------|-----:|--------:|
| large file    | `13` ms |  `0.20` ms |
| kw-heavy file | `13` ms |  `0.20` ms |
| whole project | `24` ms |  `0.16` ms |

Impressively, and unlike the baseline algorithm, this performance is achieved without any parallelization.

To compare the algorithms, first consider the baseline algorithm. First it loops through the project analysis once to find var definitions and once to find keyword definitions. Then, for each definition, it loops through the analysis once again, looking for any usages. This has quadratic performance, based on the size of the project analysis (# of definitions * # of usages).

The "v5" algorithm is linear in the size of the project analysis (# of definitions + # of usages).  Instead of looking for usages of one definition at a time, first it looks for all usages. It loops once through the project analysis to find all var usages, and once for all keyword usages. Then it loops once for all var definitions, using set logic to remove any that have usages, and another time for keyword definitions.

This is the biggest optimization, converting an O(N*N) algorithm to O(N). There are also some smaller optimizations to constrain the number of var usages that are inspected, reducing the size of N. This is particularly helpful during single-file analysis, when we can ignore usages of other namespaces.

Since whole-project linting is not much slower than single-file linting, perhaps it would be simpler to re-lint the full project after every file change. Then we wouldn't need to re-lint the files that reference the first file. I'll plan to test this on larger projects. Even if it looks like it will work, it may belong in a separate PR.

The next step is to integrate the "v5" algorithm into the real code. I plan to move what I can to the queries namespace. Any feedback at this time is welcome.

Note that this PR is based on `declare-and-defmethod-are-not-usages`, which has not been merged into the mainline yet. I'll convert it to be a PR on mainline when a decision has been made on whether to merge that branch.

- [ ] I created a issue to discuss the problem I am trying to solve or there is already a open issue.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)1
